### PR TITLE
VIH-0000  DTSPO-15909 - migrated Application Insights

### DIFF
--- a/azure-pipelines.destroy.yaml
+++ b/azure-pipelines.destroy.yaml
@@ -22,7 +22,7 @@ parameters:
 
 variables:
 - name: tfVersion
-  value: 1.3.7
+  value: 1.6.6
 - name: azureLocation
   value: 'UK South'
 - group: external

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -44,7 +44,7 @@ parameters:
 
 variables:
 - name: tfVersion
-  value: 1.3.7
+  value: 1.6.6
 - group: external
 - name: azureLocation
   value: 'UK South'

--- a/terraform/20-main.tf
+++ b/terraform/20-main.tf
@@ -389,8 +389,8 @@ module "Monitoring" {
   dynatrace_runbook_name  = module.dynatrace_runbook.runbook_name
   dynatrace_tenant        = local.dynatrace_tenant
 
-  env = local.environment
-
+  env     = local.environment
+  product = var.product
   action_groups = {
     "kinly" = {
       emails = split(",", var.emails_kinly)

--- a/terraform/modules/Monitoring/alert_cron_jobs.tf
+++ b/terraform/modules/Monitoring/alert_cron_jobs.tf
@@ -51,7 +51,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "cron_jobs" {
 
   evaluation_frequency = "PT6H"
   window_duration      = "PT6H"
-  scopes               = [azurerm_application_insights.vh-infra-core.id]
+  scopes               = [module.application_insights.id]
   severity             = each.value.severity
   criteria {
     query                   = <<-QUERY

--- a/terraform/modules/Monitoring/alert_pexip.tf
+++ b/terraform/modules/Monitoring/alert_pexip.tf
@@ -10,7 +10,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "pexip" {
 
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
-  scopes               = [azurerm_application_insights.vh-infra-core.id]
+  scopes               = [module.application_insights.id]
   severity             = 1
   criteria {
     query                   = <<-QUERY

--- a/terraform/modules/Monitoring/alert_wowza.tf
+++ b/terraform/modules/Monitoring/alert_wowza.tf
@@ -9,7 +9,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "wowza_not_recording" {
     action_group = [azurerm_monitor_action_group.this["dev"].id, azurerm_monitor_action_group.this["devops"].id, azurerm_monitor_action_group.action_group_wowza_not_recording[0].id]
   }
 
-  data_source_id = azurerm_application_insights.vh-infra-core.id
+  data_source_id = module.application_insights.id
   description    = "The message \"[Judge WR] - Should not continue without a recording. Show alert\" has been seen multiple times in the last 48 hours. This likely means recordings are failing, if everything else appears good check the connectivity between Pexip (Kinly) and wowza"
   enabled        = true
 

--- a/terraform/modules/Monitoring/inputs.tf
+++ b/terraform/modules/Monitoring/inputs.tf
@@ -56,3 +56,8 @@ variable "dynatrace_tenant" {
   description = "dynatrace tenant"
   type        = string
 }
+
+variable "product" {
+  description = "product name"
+  type        = string
+}

--- a/terraform/modules/Monitoring/main.tf
+++ b/terraform/modules/Monitoring/main.tf
@@ -2,7 +2,7 @@ module "application_insights" {
   source = "git::https://github.com/hmcts/terraform-module-application-insights.git?ref=main"
 
 
-  env                 = var.environment
+  env                 = var.env
   product             = var.product
   location            = var.location
   override_name       = var.resource_prefix

--- a/terraform/modules/Monitoring/main.tf
+++ b/terraform/modules/Monitoring/main.tf
@@ -1,5 +1,6 @@
 module "application_insights" {
-  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+  source = "git::https://github.com/hmcts/terraform-module-application-insights.git?ref=main"
+
 
   env                 = var.environment
   product             = var.product

--- a/terraform/modules/Monitoring/main.tf
+++ b/terraform/modules/Monitoring/main.tf
@@ -1,10 +1,18 @@
-resource "azurerm_application_insights" "vh-infra-core" {
-  name = var.resource_prefix
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
 
+  env                 = var.environment
+  product             = var.product
   location            = var.location
+  override_name       = var.resource_prefix
   resource_group_name = var.resource_group_name
-  application_type    = "web"
-  tags                = var.tags
+
+  common_tags = var.tags
+}
+
+moved {
+  from = azurerm_application_insights.vh-infra-core
+  to   = module.application_insights.azurerm_application_insights.this
 }
 
 resource "azurerm_log_analytics_workspace" "loganalytics" {

--- a/terraform/modules/Monitoring/outputs.tf
+++ b/terraform/modules/Monitoring/outputs.tf
@@ -1,7 +1,7 @@
 output "instrumentation_key" {
-  value = azurerm_application_insights.vh-infra-core.instrumentation_key
+  value = module.application_insights.instrumentation_key
 }
 
 output "ai_connectionstring" {
-  value = azurerm_application_insights.vh-infra-core.connection_string
+  value = module.application_insights.connection_string
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.