### PR TITLE
VIH-11302 Remove references to obsolete variable groups

### DIFF
--- a/pipeline-steps/ado-vars.yaml
+++ b/pipeline-steps/ado-vars.yaml
@@ -9,7 +9,6 @@ variables:
   - group: vh-admin-web
   - group: vh-test-users
   - group: Saucelabs
-  - group: govuk-notify-${{ parameters.environment }}
   - group: vh-booking-queue-subscriber
   - group: vh-video-web-${{ parameters.environment }}
   - group: vh-user-groups

--- a/pipeline-steps/ado-vars.yaml
+++ b/pipeline-steps/ado-vars.yaml
@@ -16,7 +16,6 @@ variables:
   - group: vh-video-api
   - group: QuickLinks_${{ parameters.environment }}
   - group: QuickLinks_Common
-  - group: FeatureFlags_${{ parameters.environment }}
   - group: vh-video-web
   - group: Ejud_${{ parameters.environment }}
   - group: Dynatrace_${{ parameters.environment }}
@@ -25,10 +24,10 @@ variables:
   - group: vh-scheduler-jobs # Common values for vh-scheduler-jobs, prod/non-prod set below
   - ${{ if eq(parameters.environment, 'prod') }}:
     - group: vh-scheduler-jobs-prod
+    - group: govuk-notify-prod
+    - group: vh-common-prod
   - ${{ else }}:
     - group: vh-scheduler-jobs-non-prod
-  - ${{ if eq(parameters.environment, 'prod') }}:
-    - group: vh-common-${{ parameters.environment }}
-  - ${{ else }}:
+    - group: govuk-notify-dev
     - group: vh-common
   - group: DOM1_${{ parameters.environment }}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-11302


### Change description ###

- Remove reference to `FeatureFlags` group
- If environment is prod, use `govuk-notify-prod` group, else use `govuk-notify-dev` group
- Combined multiple `if eq(parameters.environment, 'prod'` statements into one